### PR TITLE
Use sigils for json strings to improve readability

### DIFF
--- a/lib/simple_token_authentication.ex
+++ b/lib/simple_token_authentication.ex
@@ -19,7 +19,7 @@ defmodule SimpleTokenAuthentication do
     else
       conn
       |> put_resp_content_type("application/json")
-      |> send_resp(401, "{ \"error\": \"Invalid shared key\" }")
+      |> send_resp(401, ~s({ "error": "Invalid shared key" }))
       |> halt
     end
   end


### PR DESCRIPTION
You don't need to escape all those `"` if you use sigils, and now it looks nicer